### PR TITLE
Remove unsatisfiable dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,5 +12,4 @@ galaxy_info:
   categories:
     - development
 
-dependencies:
-  - java
+dependencies: []


### PR DESCRIPTION
Remove unsatisfiable meta dependency to java assuming the user installed java previously. This solution allow users to choose their java installation, specifying java home through the java_home role variable.
